### PR TITLE
add the feature to run a headless Vim server

### DIFF
--- a/test/tests.py
+++ b/test/tests.py
@@ -117,6 +117,15 @@ class TestServer(unittest.TestCase):
         self.assertTrue('--servername' in self.vim.server._args[0])
         # server._args is a tuple which needs unpacking to get a list
 
+    def test_start_headless(self):
+        try:
+            self.vim.start_headless(testing=False, timeout=5)
+        except RuntimeError:
+            return
+        self.assertTrue(self.vim.is_running())
+        self.vim.quit()
+        self.assertFalse(self.vim.is_running())
+
     def test_start_gvim(self):
         #self.vim.start(testing=True)
         # this test might pass or not, depending if the user has gvim installed
@@ -177,6 +186,7 @@ class TestServerFunctionalTests(unittest.TestCase):
         #self.client = self.vim.start()
         self.client = self.vim.start_in_other_terminal()
         #self.client = self.vim.start_gvim()
+        #self.client = self.vim.start_headless()
 
         client = self.client
 

--- a/vimrunner/vimrunner.py
+++ b/vimrunner/vimrunner.py
@@ -156,6 +156,29 @@ class Server(object):
 
         return Client(self)
 
+    def start_headless(self, timeout=5, testing=False):
+        """Starts headless Vim server in a subprocess.
+
+            vim -n --servername GOTOWORD >/dev/null 2>&1 <&1
+
+        No input and output is connected to Vim server,
+        so that you can run a unit test without a dirty log.
+
+        testing - flag useful for tests when you don't want to start Vim server
+
+        Returns a client connected to Vim server.
+        """
+        if not testing:
+            self.server = subprocess.Popen(
+                args=self.cmd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                shell=True
+            )
+            self.check_is_running(timeout)
+        return Client(self)
+
     def start_in_other_terminal(self):
         """Start vim in a terminal other than the one used to run this script
         (test script) because vim will pollute the output of the test script


### PR DESCRIPTION
Hi, I am using vimrunner on my project's unit testing.
vimrunner almost works nicely, but [Vim server breaks a build log](https://travis-ci.org/manicmaniac/betterga/jobs/73399739)
because it runs on foreground and handles standard I/O.
So I added the feature to run Vim server without any input / output.